### PR TITLE
We have to pass skip encoding option to get special characters in the…

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -9,7 +9,7 @@ class IndexController < ApplicationController
 
   def show
     url = "#{ENV['API_URL']}/dois/#{@doi}"
-    response = Maremma.get(url, accept: "application/vnd.datacite.datacite+json", raw: true)
+    response = Maremma.get(url, accept: "application/vnd.datacite.datacite+json", raw: true, skip_encoding: true)
 
     if response.status == 200
       @metadata = Bolognese::Metadata.new(input: response.body.fetch("data", nil), from: "datacite_json")


### PR DESCRIPTION
We have this PR for Maremma, where we have to pass `skip_encoding` option `true` to skip encoding.
https://github.com/datacite/maremma/pull/16/files

Here `creatorName` has `?` in the name,

```
ashwini ~/Documents/WorkSpace/CrossCite/content-negotiation master > curl -LH "Accept: application/vnd.datacite.datacite+xml" http://localhost:8085/10.82537/9vfw-rj81  
<?xml version="1.0" encoding="UTF-8"?>
<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
  <identifier identifierType="DOI">10.82537/9VFW-RJ81</identifier>
  <creators>
    <creator>
      <creatorName nameType="Personal">Pankatz-Reu??, Miriam</creatorName>
```

expected 

```
<creatorName nameType="Personal">Pankatz-Reuß, Miriam</creatorName>
```